### PR TITLE
Add JVM Graphs

### DIFF
--- a/generate-service-overview.rb
+++ b/generate-service-overview.rb
@@ -32,6 +32,6 @@ convox_app = options[:app_name]
 
 config = YAML.safe_load(File.read(options[:file]))
 
-template = ERB.new(File.read(File.join(__dir__, 'templates', 'services-overview.erb')))
+template = ERB.new(File.read(File.join(__dir__, 'templates', 'services-overview.erb')), nil, '-')
 
 File.write(options[:output_file], template.result(binding))

--- a/generate-service-overview.rb
+++ b/generate-service-overview.rb
@@ -7,7 +7,7 @@ require 'erb'
 require 'digest'
 require 'fileutils'
 
-options = {}
+options = {jvm_graphs: false}
 OptionParser.new do |opts|
   opts.banner = 'Usage: generate-service-overview [options]'
 
@@ -15,13 +15,17 @@ OptionParser.new do |opts|
     options[:app_name] = v
   end
 
-	opts.on("-f", "--convox-file CONVOX_FILE_NAME", "Convox file to parse for information (default: docker-compose.convox.yml)") do |v|
-		options[:file] = v
-	end
+  opts.on("-f", "--convox-file CONVOX_FILE_NAME", "Convox file to parse for information (default: docker-compose.convox.yml)") do |v|
+    options[:file] = v
+  end
 
-	opts.on("-o", "--output-file TERRAFORM_TARGET_FILE", "target terraform file") do |v|
-		options[:output_file] = v
-	end
+  opts.on("-o", "--output-file TERRAFORM_TARGET_FILE", "target terraform file") do |v|
+    options[:output_file] = v
+  end
+
+  opts.on("-j", "--jvm-graphs", "Generate JVM graphs for java processes (default: disabled)") do |v|
+    options[:jvm_graphs] = v
+  end
 end.parse!
 
 raise ArgumentError, 'Missing convox app name  (define with -a)' unless options[:app_name]
@@ -29,6 +33,7 @@ raise ArgumentError, "Missing target Terraform file for output  (define with -o)
 
 repo = options[:repo]
 convox_app = options[:app_name]
+add_jvm_graphs = options[:jvm_graphs]
 
 config = YAML.safe_load(File.read(options[:file]))
 

--- a/generate-sqs-dashboard.rb
+++ b/generate-sqs-dashboard.rb
@@ -48,6 +48,6 @@ options[:input_files].each do |file|
   end)
 end
 
-template = ERB.new(File.read(File.join(__dir__, 'templates', 'sqs-dashboard.erb')))
+template = ERB.new(File.read(File.join(__dir__, 'templates', 'sqs-dashboard.erb')), nil, '-')
 
 File.write(options[:output_file], template.result(binding))

--- a/jvm-graphs.md
+++ b/jvm-graphs.md
@@ -1,0 +1,13 @@
+# JVM Graphs
+## Background
+We are using the DD Java system agent to automatically collect tracing data and
+JVM metrics. The agent instruments classes as they are loaded in order to
+generate traces and it can also collect values exposed via JMX. Since we aren't
+calling any code to configure (or use) DD, we set up the agent using environment
+variables (`DD_TRACE_GLOBAL_TAGS` and `DD_SERVICE_NAME`).
+
+## Dashboard Implementation
+When the `--jvm-graphs` option is specified, each process that has the
+`DD_SERVICE_NAME` environment variable defined in `docker-compose.convox.yml`
+will have two additional graphs added to the service dashboard; one containing
+the JVM heap size and one containing garbage collection times.

--- a/templates/dynamodb-dashboard.erb
+++ b/templates/dynamodb-dashboard.erb
@@ -5,19 +5,19 @@ resource "datadog_timeboard" "<%= convox_app.gsub(/[^a-zA-Z0-9]/,'-') %>-dynamod
   title       = "<%= convox_app %> - DynamoDB Overview"
   description = "<%= convox_app %> - DynamoDB Overview"
   read_only   = true
-
 <%- module_tables.sort_by(&:first).each do |(table_name, event_config)| -%>
+
   graph {
     title = "<%=table_name %> Write Status"
     viz   = "timeseries"
 
     request {
-      q = "max:aws.dynamodb.consumed_write_capacity_units{tablename:${module.<%=table_name %>.table_name}}.as_count()"
+      q          = "max:aws.dynamodb.consumed_write_capacity_units{tablename:${module.<%=table_name %>.table_name}}.as_count()"
       aggregator = "max"
     }
 
     request {
-      q = "max:aws.dynamodb.provisioned_write_capacity_units{tablename:${module.<%=table_name %>.table_name}}.as_count()"
+      q          = "max:aws.dynamodb.provisioned_write_capacity_units{tablename:${module.<%=table_name %>.table_name}}.as_count()"
       aggregator = "max"
     }
   }
@@ -27,7 +27,7 @@ resource "datadog_timeboard" "<%= convox_app.gsub(/[^a-zA-Z0-9]/,'-') %>-dynamod
     viz   = "timeseries"
 
     request {
-      q = "max:aws.dynamodb.write_throttle_events{tablename:${module.<%=table_name %>.table_name}}.as_count()"
+      q          = "max:aws.dynamodb.write_throttle_events{tablename:${module.<%=table_name %>.table_name}}.as_count()"
       aggregator = "max"
     }
   }
@@ -37,12 +37,12 @@ resource "datadog_timeboard" "<%= convox_app.gsub(/[^a-zA-Z0-9]/,'-') %>-dynamod
     viz   = "timeseries"
 
     request {
-      q = "max:aws.dynamodb.consumed_read_capacity_units{tablename:${module.<%=table_name %>.table_name}}.as_count()"
+      q          = "max:aws.dynamodb.consumed_read_capacity_units{tablename:${module.<%=table_name %>.table_name}}.as_count()"
       aggregator = "max"
     }
 
     request {
-      q = "max:aws.dynamodb.provisioned_read_capacity_units{tablename:${module.<%=table_name %>.table_name}}.as_count()"
+      q          = "max:aws.dynamodb.provisioned_read_capacity_units{tablename:${module.<%=table_name %>.table_name}}.as_count()"
       aggregator = "max"
     }
   }
@@ -52,49 +52,59 @@ resource "datadog_timeboard" "<%= convox_app.gsub(/[^a-zA-Z0-9]/,'-') %>-dynamod
     viz   = "timeseries"
 
     request {
-      q = "max:aws.dynamodb.read_throttle_events{tablename:${module.<%=table_name %>.table_name}}.as_count()"
+      q          = "max:aws.dynamodb.read_throttle_events{tablename:${module.<%=table_name %>.table_name}}.as_count()"
       aggregator = "max"
     }
   }
 <%- end -%>
 <%- resource_tables.sort_by(&:first).each do |(resource_name, event_config)| -%>
-   graph {
+
+  graph {
     title = "${aws_dynamodb_table.<%=resource_name %>.name} Write Status"
     viz   = "timeseries"
-     request {
-      q = "max:aws.dynamodb.consumed_write_capacity_units{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
+
+    request {
+      q          = "max:aws.dynamodb.consumed_write_capacity_units{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
       aggregator = "max"
     }
-     request {
-      q = "max:aws.dynamodb.provisioned_write_capacity_units{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
+
+    request {
+      q          = "max:aws.dynamodb.provisioned_write_capacity_units{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
       aggregator = "max"
     }
   }
-   graph {
+
+  graph {
     title = "${aws_dynamodb_table.<%=resource_name %>.name} Throttled Writes"
     viz   = "timeseries"
-     request {
-      q = "max:aws.dynamodb.write_throttle_events{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
+
+    request {
+      q          = "max:aws.dynamodb.write_throttle_events{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
       aggregator = "max"
     }
   }
-   graph {
+
+  graph {
     title = "${aws_dynamodb_table.<%=resource_name %>.name} Read Status"
     viz   = "timeseries"
-     request {
-      q = "max:aws.dynamodb.consumed_read_capacity_units{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
+
+    request {
+      q          = "max:aws.dynamodb.consumed_read_capacity_units{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
       aggregator = "max"
     }
-     request {
-      q = "max:aws.dynamodb.provisioned_read_capacity_units{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
+
+    request {
+      q          = "max:aws.dynamodb.provisioned_read_capacity_units{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
       aggregator = "max"
     }
   }
-   graph {
+
+  graph {
     title = "${aws_dynamodb_table.<%=resource_name %>.name} Throttled Read"
     viz   = "timeseries"
-     request {
-      q = "max:aws.dynamodb.read_throttle_events{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
+
+    request {
+      q          = "max:aws.dynamodb.read_throttle_events{tablename:${aws_dynamodb_table.<%=resource_name %>.name}}.as_count()"
       aggregator = "max"
     }
   }

--- a/templates/services-overview.erb
+++ b/templates/services-overview.erb
@@ -5,97 +5,99 @@ resource "datadog_timeboard" "<%= convox_app.gsub(/[^a-zA-Z]/,'-') %>-service-ov
   title       = "<%= convox_app %> - Service Overview"
   description = "<%= convox_app %> - Service Overview"
   read_only   = true
+<%- config["services"].sort_by(&:first).each do |(service_name, service_config)| -%>
 
-<% config["services"].sort_by(&:first).each do |(service_name, service_config)| %>
   graph {
-    title = "<%=service_name %> Memory In Use"
-    viz   = "timeseries"
+    title     = "<%=service_name %> Memory In Use"
+    viz       = "timeseries"
     precision = 0
 
     request {
-      q = "max:docker.mem.in_use{task_name:${var.convox_created_resource_name_prefix}-<%= convox_app %>-<%=service_name %>} by {container_name}*100"
+      q          = "max:docker.mem.in_use{task_name:${var.convox_created_resource_name_prefix}-<%= convox_app %>-<%=service_name %>} by {container_name}*100"
       aggregator = "max"
     }
   }
-<% if service_config["ports"]&.length.to_i > 0 %>
+<%- if service_config["ports"]&.length.to_i > 0 -%>
+
   graph {
-    title = "<%=service_name %> Host Health"
-    viz   = "timeseries"
+    title     = "<%=service_name %> Host Health"
+    viz       = "timeseries"
     precision = 0
 
     request {
-      q = "min:aws.elb.healthy_host_count.minimum{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}"
+      q          = "min:aws.elb.healthy_host_count.minimum{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}"
       aggregator = "min"
     }
 
     request {
-      q = "max:aws.elb.un_healthy_host_count.maximum{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}"
+      q          = "max:aws.elb.un_healthy_host_count.maximum{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}"
       aggregator = "max"
     }
   }
 
   graph {
-    title = "<%=service_name %> Surge Queue Length"
-    viz   = "timeseries"
+    title     = "<%=service_name %> Surge Queue Length"
+    viz       = "timeseries"
     precision = 0
 
     request {
-      q = "max:aws.elb.surge_queue_length{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}"
+      q          = "max:aws.elb.surge_queue_length{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}"
       aggregator = "min"
     }
   }
-<% if (service_config["labels"] || []).any?{|l| l.match?(/=https?\z/) } %>
+<%- if (service_config["labels"] || []).any?{|l| l.match?(/=https?\z/) } -%>
+
   graph {
-    title = "<%=service_name %> HTTP Response Codes"
-    viz   = "timeseries"
+    title     = "<%=service_name %> HTTP Response Codes"
+    viz       = "timeseries"
     precision = 0
 
     request {
-      q = "sum:aws.elb.httpcode_backend_2xx{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
+      q          = "sum:aws.elb.httpcode_backend_2xx{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
       aggregator = "sum"
-      type = "bars"
+      type       = "bars"
     }
 
     request {
-      q = "sum:aws.elb.httpcode_backend_3xx{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
+      q          = "sum:aws.elb.httpcode_backend_3xx{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
       aggregator = "sum"
-      type = "bars"
+      type       = "bars"
     }
 
     request {
-      q = "sum:aws.elb.httpcode_backend_4xx{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
+      q          = "sum:aws.elb.httpcode_backend_4xx{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
       aggregator = "sum"
-      type = "bars"
+      type       = "bars"
     }
 
     request {
-      q = "sum:aws.elb.httpcode_backend_5xx{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
+      q          = "sum:aws.elb.httpcode_backend_5xx{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
       aggregator = "sum"
-      type = "bars"
+      type       = "bars"
     }
   }
 
   graph {
-    title = "<%=service_name %> Latency"
-    viz   = "timeseries"
+    title     = "<%=service_name %> Latency"
+    viz       = "timeseries"
     precision = 0
 
     request {
-      q = "max:aws.elb.latency.maximum{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
+      q          = "max:aws.elb.latency.maximum{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
       aggregator = "max"
     }
 
     request {
-      q = "max:aws.elb.latency.p99{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
+      q          = "max:aws.elb.latency.p99{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
       aggregator = "max"
     }
 
     request {
-      q = "max:aws.elb.latency.p95{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
+      q          = "max:aws.elb.latency.p95{host:${lookup(convox_app.<%= convox_app %>.balancers, "<%= service_name %>")}}.as_count()"
       aggregator = "max"
     }
   }
-<% end %>
-<% end %>
-<% end %>
+<%- end -%>
+<%- end -%>
+<%- end -%>
 }

--- a/templates/services-overview.erb
+++ b/templates/services-overview.erb
@@ -17,6 +17,42 @@ resource "datadog_timeboard" "<%= convox_app.gsub(/[^a-zA-Z]/,'-') %>-service-ov
       aggregator = "max"
     }
   }
+<%- if add_jvm_graphs -%>
+<%- (service_config["environment"] || []).map {|e| e.match(/^DD_SERVICE_NAME=(.*)$/)}.compact.each do |dd_service_name_match| -%>
+
+  graph {
+    title     = "<%=service_name %> JVM Heap Memory In Use"
+    viz       = "timeseries"
+    precision = 0
+
+    request {
+      q          = "max:jvm.heap_memory{env:<%=convox_app %>,service:<%=dd_service_name_match[1] %>} by {runtime-id}"
+      aggregator = "max"
+    }
+
+    request {
+      q          = "max:jvm.heap_memory_max{env:<%=convox_app %>,service:<%=dd_service_name_match[1] %>} by {runtime-id}"
+      aggregator = "max"
+    }
+  }
+
+  graph {
+    title     = "<%=service_name %> JVM GC Time"
+    viz       = "timeseries"
+    precision = 0
+
+    request {
+      q          = "max:jvm.gc.minor_collection_time{env:<%=convox_app %>,service:<%=dd_service_name_match[1] %>} by {runtime-id}"
+      aggregator = "max"
+    }
+
+    request {
+      q          = "max:jvm.gc.major_collection_time{env:<%=convox_app %>,service:<%=dd_service_name_match[1] %>} by {runtime-id}"
+      aggregator = "max"
+    }
+  }
+<%- end -%>
+<%- end -%>
 <%- if service_config["ports"]&.length.to_i > 0 -%>
 
   graph {

--- a/templates/services-overview.erb
+++ b/templates/services-overview.erb
@@ -137,16 +137,16 @@ resource "datadog_timeboard" "<%= convox_app.gsub(/[^a-zA-Z]/,'-') %>-service-ov
 <%- end -%>
 <%- end -%>
 }
+<%- if mem_usage_opt_in == true -%>
+  <%- config["services"].sort_by(&:first).each do |(service_name, service_config)| -%>
+    <%- task_name = "${var.convox_created_resource_name_prefix}-#{convox_app}-#{service_name}" -%>
 
-<% if mem_usage_opt_in == true %>
-  <% config["services"].sort_by(&:first).each do |(service_name, service_config)| %>
-    <% task_name = "${var.convox_created_resource_name_prefix}-#{convox_app}-#{service_name}" %>
-    resource "datadog_monitor" "<%= convox_app %>-<%= service_name %>-ram-usage-monitor" {
-      name             = "${var.convox_created_resource_name_prefix}-<%= convox_app %>-<%= service_name %>-ram-usage-monitor"
-      type             = "metric alert"
-      locked           = true
-      message          = "<%= service_name %> Memory usage >= 98% for the last hour. @<%= pagerduty_team %>"
-      query            = "min(last_1h):max:docker.mem.rss{task_name:<%= task_name %>} / max:docker.mem.limit{task_name:<%= task_name %>} >= 0.98"
-    }
-  <% end %>
-<% end %>
+resource "datadog_monitor" "<%= convox_app %>-<%= service_name %>-ram-usage-monitor" {
+  name    = "${var.convox_created_resource_name_prefix}-<%= convox_app %>-<%= service_name %>-ram-usage-monitor"
+  type    = "metric alert"
+  locked  = true
+  message = "<%= service_name %> Memory usage >= 98% for the last hour. @<%= pagerduty_team %>"
+  query   = "min(last_1h):max:docker.mem.rss{task_name:<%= task_name %>} / max:docker.mem.limit{task_name:<%= task_name %>} >= 0.98"
+}
+  <%- end -%>
+<%- end -%>

--- a/templates/sqs-dashboard.erb
+++ b/templates/sqs-dashboard.erb
@@ -5,20 +5,20 @@ resource "datadog_timeboard" "<%= convox_app.gsub(/[^a-zA-Z]/,'-') %>-sqs-overvi
   title       = "<%= convox_app %> - SQS Overview"
   description = "<%= convox_app %> - SQS Overview"
   read_only   = true
+<%- domain_events.sort_by(&:first).each do |(event_name, event_config)| -%>
 
-<% domain_events.sort_by(&:first).each do |(event_name, event_config)| %>
   graph {
-    title = "<%=event_name %> Read / Write"
-    viz   = "timeseries"
+    title     = "<%=event_name %> Read / Write"
+    viz       = "timeseries"
     precision = 0
 
     request {
-      q = "sum:aws.sqs.number_of_messages_sent{queuename:${module.<%=event_name %>.sqs_queue_name}}.as_count()"
+      q          = "sum:aws.sqs.number_of_messages_sent{queuename:${module.<%=event_name %>.sqs_queue_name}}.as_count()"
       aggregator = "sum"
     }
 
     request {
-      q = "sum:aws.sqs.number_of_messages_deleted{queuename:${module.<%=event_name %>.sqs_queue_name}}.as_count()"
+      q          = "sum:aws.sqs.number_of_messages_deleted{queuename:${module.<%=event_name %>.sqs_queue_name}}.as_count()"
       aggregator = "sum"
     }
   }
@@ -30,36 +30,36 @@ resource "datadog_timeboard" "<%= convox_app.gsub(/[^a-zA-Z]/,'-') %>-sqs-overvi
     precision = 0
 
     request {
-      q = "max:aws.sqs.approximate_age_of_oldest_message{queuename:${module.<%=event_name %>.sqs_queue_name}}.as_count()"
+      q          = "max:aws.sqs.approximate_age_of_oldest_message{queuename:${module.<%=event_name %>.sqs_queue_name}}.as_count()"
       aggregator = "last"
 
       conditional_format {
         comparator = "<"
-        value = 300
-        palette = "white_on_green"
+        value      = 300
+        palette    = "white_on_green"
       }
 
       conditional_format {
         comparator = ">"
-        value = 299
-        palette = "white_on_yellow"
+        value      = 299
+        palette    = "white_on_yellow"
       }
+
       conditional_format {
         comparator = ">"
-        value = 600
-        palette = "white_on_red"
+        value      = 600
+        palette    = "white_on_red"
       }
     }
-
   }
 
   graph {
-    title = "<%=event_name %> Dead Letter Queue Size"
-    viz   = "timeseries"
+    title     = "<%=event_name %> Dead Letter Queue Size"
+    viz       = "timeseries"
     precision = 0
 
     request {
-      q = "sum:aws.sqs.approximate_number_of_messages_visible{queuename:${module.<%=event_name %>.sqs_dead_letter_queue_name}}.as_count()"
+      q          = "sum:aws.sqs.approximate_number_of_messages_visible{queuename:${module.<%=event_name %>.sqs_dead_letter_queue_name}}.as_count()"
       aggregator = "sum"
     }
   }
@@ -71,43 +71,43 @@ resource "datadog_timeboard" "<%= convox_app.gsub(/[^a-zA-Z]/,'-') %>-sqs-overvi
     precision = 0
 
     request {
-      q = "max:aws.sqs.approximate_age_of_oldest_message{queuename:${module.<%=event_name %>.sqs_dead_letter_queue_name}}.as_count()"
+      q          = "max:aws.sqs.approximate_age_of_oldest_message{queuename:${module.<%=event_name %>.sqs_dead_letter_queue_name}}.as_count()"
       aggregator = "last"
 
       conditional_format {
         comparator = "<"
-        value = 1
-        palette = "white_on_green"
+        value      = 1
+        palette    = "white_on_green"
       }
 
       conditional_format {
         comparator = ">"
-        value = 1
-        palette = "white_on_yellow"
+        value      = 1
+        palette    = "white_on_yellow"
       }
+
       conditional_format {
         comparator = ">"
-        value = 3
-        palette = "white_on_red"
+        value      = 3
+        palette    = "white_on_red"
       }
     }
-
   }
-<% end %>
+<%- end -%>
+<%- sqs_queues.each do |queue_name, queue_config| -%>
 
-<% sqs_queues.each do |queue_name, queue_config| %>
   graph {
-    title = "<%=queue_name %> Read / Write"
-    viz   = "timeseries"
+    title     = "<%=queue_name %> Read / Write"
+    viz       = "timeseries"
     precision = 0
 
     request {
-      q = "sum:aws.sqs.number_of_messages_sent{queuename:<%= queue_config["name"] %>}.as_count()"
+      q          = "sum:aws.sqs.number_of_messages_sent{queuename:<%= queue_config["name"] %>}.as_count()"
       aggregator = "sum"
     }
 
     request {
-      q = "sum:aws.sqs.number_of_messages_deleted{queuename:<%= queue_config["name"] %>}.as_count()"
+      q          = "sum:aws.sqs.number_of_messages_deleted{queuename:<%= queue_config["name"] %>}.as_count()"
       aggregator = "sum"
     }
   }
@@ -119,26 +119,27 @@ resource "datadog_timeboard" "<%= convox_app.gsub(/[^a-zA-Z]/,'-') %>-sqs-overvi
     precision = 0
 
     request {
-      q = "max:aws.sqs.approximate_age_of_oldest_message{queuename:<%= queue_config["name"] %>}.as_count()"
+      q          = "max:aws.sqs.approximate_age_of_oldest_message{queuename:<%= queue_config["name"] %>}.as_count()"
       aggregator = "last"
 
       conditional_format {
         comparator = "<"
-        value = 1
-        palette = "white_on_green"
+        value      = 1
+        palette    = "white_on_green"
       }
 
       conditional_format {
         comparator = ">"
-        value = 1
-        palette = "white_on_yellow"
+        value      = 1
+        palette    = "white_on_yellow"
       }
+
       conditional_format {
         comparator = ">"
-        value = 3
-        palette = "white_on_red"
+        value      = 3
+        palette    = "white_on_red"
       }
     }
   }
-<% end %>
+<%- end -%>
 }


### PR DESCRIPTION
This PR:
* Updates the templates to match `terraform fmt`.
* Add an option to generate graphs of JVM metrics collected by the DD java system agent.
I added a markdown file to provide some context for these changes. It probably belongs in the man repo though.